### PR TITLE
Remove box syntax

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -191,8 +191,8 @@ impl SimplExpr {
                 }
             }
             SimplExpr::FunctionCall(span, function_name, args) => {
-                let args = args.into_iter().map(|a| a.eval(values)).collect::<Result<_, EvalError>>()?;
-                call_expr_function(&function_name, args).map_err(|e| e.at(*span))
+                let args = args.iter().map(|a| a.eval(values)).collect::<Result<_, EvalError>>()?;
+                call_expr_function(function_name, args).map_err(|e| e.at(*span))
             }
         };
         Ok(value?.at(span))
@@ -214,7 +214,7 @@ fn call_expr_function(name: &str, args: Vec<DynVal>) -> Result<DynVal, EvalError
                 let string = string.as_string()?;
                 let pattern = regex::Regex::new(&pattern.as_string()?)?;
                 let replacement = replacement.as_string()?;
-                Ok(DynVal::from(pattern.replace_all(&string, replacement.replace("$", "$$").replace("\\", "$")).into_owned()))
+                Ok(DynVal::from(pattern.replace_all(&string, replacement.replace('$', "$$").replace('\\', "$")).into_owned()))
             }
             _ => Err(EvalError::WrongArgCount(name.to_string())),
         },

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -61,10 +61,10 @@ impl SimplExpr {
     pub fn map_terminals_into(self, f: impl Fn(Self) -> Self) -> Self {
         use SimplExpr::*;
         match self {
-            BinOp(span, box a, op, box b) => BinOp(span, box f(a), op, box f(b)),
-            UnaryOp(span, op, box a) => UnaryOp(span, op, box f(a)),
-            IfElse(span, box a, box b, box c) => IfElse(span, box f(a), box f(b), box f(c)),
-            JsonAccess(span, box a, box b) => JsonAccess(span, box f(a), box f(b)),
+            BinOp(span, box a, op, box b) => BinOp(span, Box::new(f(a)), op, Box::new(f(b))),
+            UnaryOp(span, op, box a) => UnaryOp(span, op, Box::new(f(a))),
+            IfElse(span, box a, box b, box c) => IfElse(span, Box::new(f(a)), Box::new(f(b)), Box::new(f(c))),
+            JsonAccess(span, box a, box b) => JsonAccess(span, Box::new(f(a)), Box::new(f(b))),
             FunctionCall(span, name, args) => FunctionCall(span, name, args.into_iter().map(f).collect()),
             other => f(other),
         }
@@ -76,13 +76,13 @@ impl SimplExpr {
         match self {
             // Literal(x) => Ok(Literal(AttrValue::from_primitive(x.resolve_fully(&variables)?))),
             Literal(span, x) => Ok(Literal(span, x)),
-            BinOp(span, box a, op, box b) => Ok(BinOp(span, box a.resolve_refs(variables)?, op, box b.resolve_refs(variables)?)),
-            UnaryOp(span, op, box x) => Ok(UnaryOp(span, op, box x.resolve_refs(variables)?)),
+            BinOp(span, box a, op, box b) => Ok(BinOp(span, Box::new(a.resolve_refs(variables)?), op, Box::new(b.resolve_refs(variables)?))),
+            UnaryOp(span, op, box x) => Ok(UnaryOp(span, op, Box::new(x.resolve_refs(variables)?))),
             IfElse(span, box a, box b, box c) => {
-                Ok(IfElse(span, box a.resolve_refs(variables)?, box b.resolve_refs(variables)?, box c.resolve_refs(variables)?))
+                Ok(IfElse(span, Box::new(a.resolve_refs(variables)?), Box::new(b.resolve_refs(variables)?), Box::new(c.resolve_refs(variables)?)))
             }
             JsonAccess(span, box a, box b) => {
-                Ok(JsonAccess(span, box a.resolve_refs(variables)?, box b.resolve_refs(variables)?))
+                Ok(JsonAccess(span, Box::new(a.resolve_refs(variables)?), Box::new(b.resolve_refs(variables)?)))
             }
             FunctionCall(span, function_name, args) => Ok(FunctionCall(
                 span,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(try_blocks)]
 pub mod ast;
 pub mod dynval;


### PR DESCRIPTION
`box_syntax` has been removed from rust as of https://github.com/rust-lang/rust/pull/108471. Use `Box::new` instead.

I've also applied some clippy suggestions.